### PR TITLE
1206687194340255 - Matches Types percentages are not calculated correctly when there is excluded text

### DIFF
--- a/projects/copyleaks-web-report/src/lib/components/containers/report-tabs-container/report-tabs-container.component.html
+++ b/projects/copyleaks-web-report/src/lib/components/containers/report-tabs-container/report-tabs-container.component.html
@@ -16,17 +16,17 @@
 					? null
 					: {
 							identicalPct: {
-								percentage: identicalTotal / wordsTotal,
+								percentage: wordsTotal - excludedTotal === 0 ? 0 : identicalTotal / (wordsTotal - excludedTotal),
 								totalWords: identicalTotal ?? 0,
 								disabled: reportDataSvc.filterOptions?.showIdentical === false
 							},
 							minorChangesPct: {
-								percentage: minorChangesTotal / wordsTotal,
+								percentage: wordsTotal - excludedTotal === 0 ? 0 : minorChangesTotal / (wordsTotal - excludedTotal),
 								totalWords: minorChangesTotal ?? 0,
 								disabled: reportDataSvc.filterOptions?.showMinorChanges === false
 							},
 							paraphrasedPct: {
-								percentage: paraphrasedTotal / wordsTotal,
+								percentage: wordsTotal - excludedTotal === 0 ? 0 : paraphrasedTotal / (wordsTotal - excludedTotal),
 								totalWords: paraphrasedTotal ?? 0,
 								disabled: reportDataSvc.filterOptions?.showRelated === false
 							},


### PR DESCRIPTION
Matches Types percentages are not calculated correctly when there is excluded text.
This only is happening for the tabs tooltips, the results score tooltip is calculated correctly (we are decreasing the total excluded from the total words)