### PR TITLE
1207110728026529 web-report-accessibility-check-tabs-fix

### DIFF
--- a/projects/copyleaks-web-report/src/lib/components/core/cr-custom-tabs/components/cr-custom-tab-item/cr-custom-tab-item.component.html
+++ b/projects/copyleaks-web-report/src/lib/components/core/cr-custom-tabs/components/cr-custom-tab-item/cr-custom-tab-item.component.html
@@ -2,6 +2,8 @@
 	<button
 		class="custom-tab"
 		(click)="clickEvent()"
+		[tabindex]="0"
+		(keyup.enter)="clickEvent()"
 		[style.flex-grow]="flexGrow"
 		[class.tab-selected]="selected"
 		aria-label="Click to switch to tab"


### PR DESCRIPTION
This fixes the accessibility scenario where the user want to navigate between the report tabs and one of the tabs is a custom tab, now it will be focused like other tabs and open the custom view on enter click