### PR TITLE
Features/lms sprint 33/lms 3734 development exclude self matching assignments

### DIFF
--- a/projects/copyleaks-web-report/src/lib/components/containers/report-results-item-container/components/report-expand-result-item/report-expand-result-item.component.ts
+++ b/projects/copyleaks-web-report/src/lib/components/containers/report-results-item-container/components/report-expand-result-item/report-expand-result-item.component.ts
@@ -212,9 +212,7 @@ export class ReportExpandResultItemComponent implements OnInit, OnChanges {
 		} else this.isAiSourceResult = false;
 
 		// Prioritize 'self-match' tag right after 'ai-source-match'
-		const selfMatchTag = this.resultItem?.resultPreview?.tags?.find(
-			tag => tag.code === RESULT_TAGS_CODES.SELF_MATCH
-		);
+		const selfMatchTag = this.resultItem?.resultPreview?.tags?.find(tag => tag.code === RESULT_TAGS_CODES.SELF_MATCH);
 		if (selfMatchTag) {
 			const otherTags = this.resultItem.resultPreview.tags.filter(tag => tag.code !== RESULT_TAGS_CODES.SELF_MATCH);
 			const aiIdx = otherTags.findIndex(tag => tag.code === RESULT_TAGS_CODES.AI_SOURCE_MATCH);

--- a/projects/copyleaks-web-report/src/lib/components/containers/report-results-item-container/components/report-expand-result-item/report-expand-result-item.component.ts
+++ b/projects/copyleaks-web-report/src/lib/components/containers/report-results-item-container/components/report-expand-result-item/report-expand-result-item.component.ts
@@ -210,6 +210,21 @@ export class ReportExpandResultItemComponent implements OnInit, OnChanges {
 				...this.resultItem.resultPreview.tags.filter(tag => tag.code !== RESULT_TAGS_CODES.AI_SOURCE_MATCH),
 			];
 		} else this.isAiSourceResult = false;
+
+		// Prioritize 'self-match' tag right after 'ai-source-match'
+		const selfMatchTag = this.resultItem?.resultPreview?.tags?.find(
+			tag => tag.code === RESULT_TAGS_CODES.SELF_MATCH
+		);
+		if (selfMatchTag) {
+			const otherTags = this.resultItem.resultPreview.tags.filter(tag => tag.code !== RESULT_TAGS_CODES.SELF_MATCH);
+			const aiIdx = otherTags.findIndex(tag => tag.code === RESULT_TAGS_CODES.AI_SOURCE_MATCH);
+			if (aiIdx >= 0) {
+				otherTags.splice(aiIdx + 1, 0, selfMatchTag);
+			} else {
+				otherTags.unshift(selfMatchTag);
+			}
+			this.resultItem.resultPreview.tags = otherTags;
+		}
 	}
 
 	clickBack() {

--- a/projects/copyleaks-web-report/src/lib/components/containers/report-results-item-container/components/report-results-item/report-results-item.component.ts
+++ b/projects/copyleaks-web-report/src/lib/components/containers/report-results-item-container/components/report-results-item/report-results-item.component.ts
@@ -138,6 +138,14 @@ export class ReportResultsItemComponent implements OnInit, OnChanges, OnDestroy 
 	}
 
 	get authorName() {
+		// Always show author for self-match results; use 'Anonymous' if author not available
+		const isSelfMatch = this.resultItem?.resultPreview?.tags?.some(
+			tag => tag.code === RESULT_TAGS_CODES.SELF_MATCH
+		);
+		if (isSelfMatch) {
+			return this.previewResult?.metadata?.author || this.previewResult?.metadata?.submittedBy || $localize`Anonymous`;
+		}
+
 		if (
 			this.previewResult?.metadata?.author &&
 			!(this.previewResult?.scanId && this.resultItem?.resultPreview?.type === EResultPreviewType.Database)
@@ -180,6 +188,14 @@ export class ReportResultsItemComponent implements OnInit, OnChanges, OnDestroy 
 			aiSourceMatchTag.title = $localize`AI Source Match`;
 			aiSourceMatchTag.description = $localize`AI Source Match blends plagiarism and AI detection to identify reused or repurposed AI-generated content from other sources.`;
 			return aiSourceMatchTag;
+		}
+
+		// Prioritize Self-Match tag
+		const selfMatchTag = this.resultItem?.resultPreview?.tags.find(
+			tag => tag.code === RESULT_TAGS_CODES.SELF_MATCH
+		);
+		if (selfMatchTag) {
+			return selfMatchTag;
 		}
 
 		return this.resultItem.resultPreview.tags[0];
@@ -322,6 +338,19 @@ export class ReportResultsItemComponent implements OnInit, OnChanges, OnDestroy 
 				aiSourceMatchTag,
 				...this.previewResult.tags.filter(tag => tag.code !== RESULT_TAGS_CODES.AI_SOURCE_MATCH),
 			];
+		}
+
+		// Prioritize 'self-match' tag right after 'ai-source-match' (or first if no ai-source-match)
+		const selfMatchTag = this.previewResult?.tags?.find(tag => tag.code === RESULT_TAGS_CODES.SELF_MATCH);
+		if (selfMatchTag) {
+			const otherTags = this.previewResult.tags.filter(tag => tag.code !== RESULT_TAGS_CODES.SELF_MATCH);
+			const aiIdx = otherTags.findIndex(tag => tag.code === RESULT_TAGS_CODES.AI_SOURCE_MATCH);
+			if (aiIdx >= 0) {
+				otherTags.splice(aiIdx + 1, 0, selfMatchTag);
+			} else {
+				otherTags.unshift(selfMatchTag);
+			}
+			this.previewResult.tags = otherTags;
 		}
 	}
 

--- a/projects/copyleaks-web-report/src/lib/components/containers/report-results-item-container/components/report-results-item/report-results-item.component.ts
+++ b/projects/copyleaks-web-report/src/lib/components/containers/report-results-item-container/components/report-results-item/report-results-item.component.ts
@@ -139,9 +139,7 @@ export class ReportResultsItemComponent implements OnInit, OnChanges, OnDestroy 
 
 	get authorName() {
 		// Always show author for self-match results; use 'Anonymous' if author not available
-		const isSelfMatch = this.resultItem?.resultPreview?.tags?.some(
-			tag => tag.code === RESULT_TAGS_CODES.SELF_MATCH
-		);
+		const isSelfMatch = this.resultItem?.resultPreview?.tags?.some(tag => tag.code === RESULT_TAGS_CODES.SELF_MATCH);
 		if (isSelfMatch) {
 			return this.previewResult?.metadata?.author || this.previewResult?.metadata?.submittedBy || $localize`Anonymous`;
 		}
@@ -191,9 +189,7 @@ export class ReportResultsItemComponent implements OnInit, OnChanges, OnDestroy 
 		}
 
 		// Prioritize Self-Match tag
-		const selfMatchTag = this.resultItem?.resultPreview?.tags.find(
-			tag => tag.code === RESULT_TAGS_CODES.SELF_MATCH
-		);
+		const selfMatchTag = this.resultItem?.resultPreview?.tags.find(tag => tag.code === RESULT_TAGS_CODES.SELF_MATCH);
 		if (selfMatchTag) {
 			return selfMatchTag;
 		}

--- a/projects/copyleaks-web-report/src/lib/constants/report-result-tags.constants.ts
+++ b/projects/copyleaks-web-report/src/lib/constants/report-result-tags.constants.ts
@@ -3,4 +3,5 @@ export const RESULT_TAGS_CODES = {
 	ORGANIZATION: 'organization',
 	SUMMARY_DATE: 'summary-date',
 	AI_SOURCE_MATCH: 'ai-source-match',
+	SELF_MATCH: 'self-match',
 };

--- a/projects/copyleaks-web-report/src/lib/models/report-data.models.ts
+++ b/projects/copyleaks-web-report/src/lib/models/report-data.models.ts
@@ -127,6 +127,18 @@ export interface IResultPreviews {
 	batch: IBatchResultPreview[];
 	repositories?: IRepositoryResultPreview[];
 	score: IScore;
+	selfMatchExcluded?: ISelfMatchExcludedResults;
+}
+
+/**
+ * Results automatically excluded because they were submitted by the same student
+ * in another assignment within the same course.
+ */
+export interface ISelfMatchExcludedResults {
+	internet: IInternetResultPreview[];
+	database: IDatabaseResultPreview[];
+	batch: IBatchResultPreview[];
+	repositories?: IRepositoryResultPreview[];
 }
 
 /*

--- a/projects/copyleaks-web-report/src/lib/services/report-data.service.ts
+++ b/projects/copyleaks-web-report/src/lib/services/report-data.service.ts
@@ -1145,8 +1145,49 @@ export class ReportDataService {
 			result.type = EResultPreviewType.Repositroy;
 		});
 
-		// Load the excluded results Ids
-		this._excludedResultsIds$.next(completeResultsRes.filters?.execludedResultIds ?? []);
+		// Process self-match excluded results: tag them, merge into main arrays, and auto-exclude
+		const selfMatchExcludedIds: string[] = [];
+		const selfMatchExcluded = completeResultsRes.results.selfMatchExcluded;
+		if (selfMatchExcluded) {
+			const selfMatchTag = {
+				code: RESULT_TAGS_CODES.SELF_MATCH,
+				title: $localize`Self-Match`,
+				description: $localize`This source was automatically excluded since it was submitted by the same student to another assignment in this course.`,
+			};
+
+			const tagAndCollect = (results: IResultPreviewBase[], type: EResultPreviewType) => {
+				results.forEach(result => {
+					result.type = type;
+					if (!result.tags) result.tags = [];
+					result.tags.unshift(selfMatchTag);
+					selfMatchExcludedIds.push(result.id);
+				});
+			};
+
+			tagAndCollect(selfMatchExcluded.internet ?? [], EResultPreviewType.Internet);
+			tagAndCollect(selfMatchExcluded.database ?? [], EResultPreviewType.Database);
+			tagAndCollect(selfMatchExcluded.batch ?? [], EResultPreviewType.Batch);
+			tagAndCollect(selfMatchExcluded.repositories ?? [], EResultPreviewType.Repositroy);
+
+			// Merge self-match results into main result arrays so they appear in excluded list
+			completeResultsRes.results.internet = [
+				...completeResultsRes.results.internet,
+				...(selfMatchExcluded.internet ?? []),
+			];
+			completeResultsRes.results.database = [
+				...completeResultsRes.results.database,
+				...(selfMatchExcluded.database ?? []),
+			];
+			completeResultsRes.results.batch = [...completeResultsRes.results.batch, ...(selfMatchExcluded.batch ?? [])];
+			completeResultsRes.results.repositories = [
+				...(completeResultsRes.results.repositories ?? []),
+				...(selfMatchExcluded.repositories ?? []),
+			];
+		}
+
+		// Load the excluded results Ids (include self-match excluded IDs)
+		const existingExcludedIds = completeResultsRes.filters?.execludedResultIds ?? [];
+		this._excludedResultsIds$.next([...existingExcludedIds, ...selfMatchExcludedIds]);
 
 		// Load the excluded corrections
 		this._excludedCorrections$.next(completeResultsRes.filters?.writingFeedback?.excludedCorrections ?? []);


### PR DESCRIPTION
- Support the new `selfMatchExcluded` section in the completed webhook response, which contains results automatically excluded because they were submitted by the same student to another assignment in the same course
- Self-match results are merged into the main results arrays and auto-added to the excluded list on load, so they appear in the "Excluded Matching Results" dialog
- Each self-match result gets a "Self-Match" chip with a tooltip explaining the exclusion reason
- Student name is displayed next to the chip; falls back to "Anonymous" when the author is not available
- Users can manually include a self-match result back into the report — the score updates accordingly and the Self-Match label is preserved on the result card